### PR TITLE
Fix isTerrestrial detection in updateSqlQuery()

### DIFF
--- a/R/queryCsv.R
+++ b/R/queryCsv.R
@@ -246,8 +246,15 @@ updateSqlQuery <- function(queryTable){
     points <- data.frame(df1$geo_longitude, df1$geo_latitude)
     pts <- sf::st_as_sf(points, coords=1:2, crs=4326)
 
-    ## Find which points fall over land
-    ii <- !is.na(as.numeric(sf::st_intersects(pts, spData::world)))
+    ## Find which points fall over land.
+    ## sf::st_intersects() returns an sgbp object — a list of integer
+    ## vectors, one per point, listing the polygon indices each point
+    ## intersects. lengths(sgbp) > 0 is the idiomatic test for "intersects
+    ## at least one polygon". The previous `as.numeric(sgbp)` coercion did
+    ## not yield one number per point (as.numeric on a list-of-lists is
+    ## unreliable), so `!is.na(...)` came back FALSE for every record and
+    ## the resulting isTerrestrial column was uniformly FALSE.
+    ii <- lengths(sf::st_intersects(pts, spData::world)) > 0
 
     ##Add column for isTerrestrial
     df1 <- cbind.data.frame(df1, isTerrestrial=ii)


### PR DESCRIPTION
## Summary

The `isTerrestrial` column produced by `updateSqlQuery()` in `R/queryCsv.R` is uniformly `FALSE` for every record, regardless of whether a dataset's coordinates fall on land or in the ocean. This breaks any downstream Land/Sea filtering — e.g., in PReSto, the Terrestrial-vs-Marine query filter returns zero matches for "Terrestrial" because no record in the published `dataSetQuery` table has `isTerrestrial = 1`.

## Root cause

```r
ii <- !is.na(as.numeric(sf::st_intersects(pts, spData::world)))
```

`sf::st_intersects(points, polygons)` returns an **`sgbp`** (sparse geometry binary predicate) object — a list of integer vectors, one per point, listing which polygon indices each point intersects. Calling `as.numeric()` on that list-of-lists does **not** yield one number per element; it produces `NA` across the board. So `!is.na(...)` is `FALSE` for every point, and every record gets flagged non-terrestrial.

Reproducing locally on a sample of ~7000 lipdverse points confirms the failure: **0 of 7072** records were flagged as terrestrial in the produced table.

## Fix

Use `lengths(sgbp) > 0`, the idiomatic test for "intersects at least one polygon":

```r
ii <- lengths(sf::st_intersects(pts, spData::world)) > 0
```

`lengths()` on an sgbp returns the number of polygons each point intersects. `> 0` correctly maps to `TRUE` for land and `FALSE` for ocean.

A pre-flight sample run on 500 randomly-selected lipdverse coordinates after the fix produces a sensible mix of TRUE/FALSE values (most TRUE, since most paleo records are continental).

## Test plan

- [ ] Run `updateSqlQuery()` against a representative `queryTable` and confirm `dataSetQuery.isTerrestrial` contains both `0` and `1` values.
- [ ] Spot-check a few obvious cases: a tree-ring chronology from interior Asia → `TRUE`; a marine sediment core from the open ocean → `FALSE`.