### PR TITLE
Allow updateSqlQuery() to accept caller-supplied DB connections

### DIFF
--- a/R/queryCsv.R
+++ b/R/queryCsv.R
@@ -220,7 +220,7 @@ datasetIDcollapse <- function(x){stringr::str_remove(paste0(na.omit(unique(x)), 
 
 
 
-updateSqlQuery <- function(queryTable){
+updateSqlQuery <- function(queryTable, connections = NULL){
 
     # ========== EXISTING CODE: Create dataset-level summary ==========
     df1 <- queryTable |>
@@ -283,39 +283,62 @@ updateSqlQuery <- function(queryTable){
     queryTable_clean[queryTable_clean == "NA"] <- NA
 
     # ========== DATABASE CONNECTION AND UPDATES ==========
-    #connection info
-    conInf <- readr::read_tsv("sql.secret",col_names = FALSE,col_types = "c")
+    # If the caller did not supply any connections, fall back to the
+    # legacy behavior: read sql.secret from the working directory and
+    # connect to the historical lipdverse host. This preserves backward
+    # compatibility for existing pipelines.
+    owns_connections <- is.null(connections)
+    if (owns_connections) {
+      conInf <- readr::read_tsv("sql.secret", col_names = FALSE, col_types = "c")
+      connections <- list(RMySQL::dbConnect(
+        RMySQL::MySQL(),
+        dbname   = 'lipdverse',
+        host     = '143.198.98.66',
+        port     = 3306,
+        user     = conInf$X1[[1]],
+        password = conInf$X1[[2]]
+      ))
+    } else if (inherits(connections, "DBIConnection")) {
+      # Allow callers to pass a single connection without wrapping it.
+      connections <- list(connections)
+    }
 
-    mysqlconnection = RMySQL::dbConnect(RMySQL::MySQL(),
-                                        dbname='lipdverse',
-                                        host='143.198.98.66',
-                                        port=3306,
-                                        user=conInf$X1[[1]],
-                                        password=conInf$X1[[2]])
+    for (i in seq_along(connections)) {
+      con <- connections[[i]]
 
-    # Update dataSetQuery table (dataset-level aggregation)
-    print("Writing to dataSetQuery table...")
-    RMySQL::dbWriteTable(mysqlconnection, "dataSetQuery", df1, overwrite=TRUE)
-    print("dataSetQuery updated")
+      # Best-effort label for logging - DBI::dbGetInfo() returns
+      # connection metadata that varies by driver, so fall back to a
+      # generic label if anything goes wrong.
+      target_label <- tryCatch({
+        info <- DBI::dbGetInfo(con)
+        paste0(info$user, "@", info$host, ":", info$port, "/", info$dbname)
+      }, error = function(e) paste0("connection ", i))
+      print(paste0("Updating ", target_label, "..."))
 
-    # Update query table (time-series level)
-    print("Writing to query table...")
-    RMySQL::dbWriteTable(mysqlconnection, "query", queryTable_clean, overwrite=TRUE)
-    print("query updated")
+      # Update dataSetQuery table (dataset-level aggregation)
+      print("Writing to dataSetQuery table...")
+      RMySQL::dbWriteTable(con, "dataSetQuery", df1, overwrite = TRUE)
+      print("dataSetQuery updated")
 
-    # Verify the updates
-    print("Verifying updates...")
+      # Update query table (time-series level)
+      print("Writing to query table...")
+      RMySQL::dbWriteTable(con, "query", queryTable_clean, overwrite = TRUE)
+      print("query updated")
 
-    # Check dataSetQuery count
-    dataset_count <- DBI::dbGetQuery(mysqlconnection, "SELECT COUNT(*) as count FROM dataSetQuery")
-    print(paste("  dataSetQuery now has", dataset_count$count, "rows"))
+      # Verify the updates
+      print("Verifying updates...")
+      dataset_count <- DBI::dbGetQuery(con, "SELECT COUNT(*) as count FROM dataSetQuery")
+      print(paste("  dataSetQuery now has", dataset_count$count, "rows"))
+      query_count <- DBI::dbGetQuery(con, "SELECT COUNT(*) as count FROM query")
+      print(paste("  query now has", query_count$count, "rows"))
 
-    # Check query count
-    query_count <- DBI::dbGetQuery(mysqlconnection, "SELECT COUNT(*) as count FROM query")
-    print(paste("  query now has", query_count$count, "rows"))
-
-    # Close connection
-    RMySQL::dbDisconnect(mysqlconnection)
+      # Only disconnect connections this function created. Caller-supplied
+      # connections remain the caller's responsibility (they may want to
+      # reuse them for further work).
+      if (owns_connections) {
+        RMySQL::dbDisconnect(con)
+      }
+    }
 
     print("Database update complete!")
 }


### PR DESCRIPTION
## Summary

`updateSqlQuery()` currently hard-codes the database connection — it reads `sql.secret` from the working directory and connects to `host='143.198.98.66', port=3306`. That works on hosts where the MySQL service is reachable from outside its docker network on a publicly exposed port, but breaks in two common cases:

1. **MySQL is internal-only.** On deployments where the production MySQL container has no host port mapping (only the docker bridge address), the hardcoded `host='143.198.98.66'` connection cannot succeed at all from outside the droplet. Callers running inside the docker network would naturally use `host='mysql'` (or whatever service alias they've defined) — which the current API doesn't allow.
2. **Multiple targets.** Some pipelines need to fan the same update out to more than one MySQL instance (e.g. primary + staging replica, or two regional deployments) without duplicating the data-prep pipeline.

## Change

Add an optional `connections = NULL` parameter to `updateSqlQuery()`:

```r
updateSqlQuery <- function(queryTable, connections = NULL) { ... }
```

- **`connections = NULL`** (the default): unchanged behavior. The function reads `sql.secret` and connects to `host='143.198.98.66', port=3306`. All existing callers continue to work without modification.
- **`connections = <DBIConnection>`**: a single connection, used directly.
- **`connections = list(<conn1>, <conn2>, ...)`**: multiple connections, each receives the same update.

The function only disconnects connections it created itself; caller-supplied connections remain the caller's responsibility (so they can be reused for follow-up queries in the same R session).

## Example: connect via docker service alias

```r
con <- RMySQL::dbConnect(
  RMySQL::MySQL(),
  host     = Sys.getenv("MYSQL_HOST"),     # e.g. "mysql"
  port     = 3306,
  dbname   = Sys.getenv("MYSQL_DATABASE"),
  user     = Sys.getenv("MYSQL_USER"),
  password = Sys.getenv("MYSQL_PASSWORD")
)
updateSqlQuery(qt, connections = con)
DBI::dbDisconnect(con)
```

## Example: fan out to multiple targets

```r
prod <- RMySQL::dbConnect(..., host = "prod-host", ...)
stg  <- RMySQL::dbConnect(..., host = "stage-host", ...)
updateSqlQuery(qt, connections = list(prod, stg))
DBI::dbDisconnect(prod); DBI::dbDisconnect(stg)
```

## Test plan

- [ ] Call with no `connections` arg, alongside a present `sql.secret` — verify the legacy path still connects to the historical host and updates both tables.
- [ ] Call with a single `RMySQL::dbConnect()` result — verify a single update pass executes against that connection and that the connection is **not** closed afterward.
- [ ] Call with `list(con1, con2)` — verify both targets receive identical row counts in `dataSetQuery` and `query`.
- [ ] Verify per-target log line shows the actual host being written to.

## Notes for reviewers

- This is independent of #7 (the `isTerrestrial` bug fix). Both branches are based on master; if #7 merges first this PR rebases trivially. If this merges first, #7 rebases trivially. Each can be reviewed on its own merits.
- No new package dependencies. Uses `DBI::dbGetInfo()` (already pulled in transitively via `RMySQL`) for the per-target log label, with a `tryCatch` fallback in case a future driver returns an unexpected info shape.